### PR TITLE
remove-appcelerator-reference

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -32,9 +32,9 @@ FeedHenry:
 
 | Component | Description | Source Code
 | -
-| [Client SDKs]({{ "/projects/#client-sdks" | relative_url }}) | Native and hybrid SDKs for client app development on iOS, Android, Windows, Xamarin, Appcelerator, Cordova, and in web apps. | <span class="tag tag-success">Available</span>
+| [Client SDKs]({{ "/projects/#client-sdks" | relative_url }}) | Native and hybrid SDKs for client app development on iOS, Android, Windows, Xamarin, Cordova, and in web apps. | <span class="tag tag-success">Available</span>
 | [Push Notifications]({{ "/projects/#push-notifications" | relative_url }}) | Integration with AeroGear for sending push notifications to any device, regardless of platform or network. | <span class="tag tag-success">Available</span>
-| [App Templates]({{ "/projects/#app-templates" | relative_url }}) | Starting points for building your applications with FeedHenry, including templates for iOS, Android, Xamarin, Appcelerator, Cordova; OAuth2 and SAML examples, push notification and data synchronization examples, and many more. | <span class="tag tag-success">Available</span>
+| [App Templates]({{ "/projects/#app-templates" | relative_url }}) | Starting points for building your applications with FeedHenry, including templates for iOS, Android, Xamarin, Cordova; OAuth2 and SAML examples, push notification and data synchronization examples, and many more. | <span class="tag tag-success">Available</span>
 | [RainCatcher]({{ "/projects/#raincatcher" | relative_url }}) | A set of Node.js modules that can be used with FeedHenry to develop workforce management applications. | <span class="tag tag-success">Available</span>
 | [Core]({{ "/projects/#core" | relative_url }}) | The core components that make up FeedHenry, including drag & drop forms builder, application lifecycle management, reporting, analytics, user management, and more. | <span class="tag tag-info">Coming soon</span>
 | [MBaaS]({{ "/projects/#mbaas" | relative_url }}) | Provides the Node.js runtime environment for high-performance server-side apps (cloud apps) and enables secure integrations with internal systems behind the firewall. | <span class="tag tag-info">Coming soon</span>


### PR DESCRIPTION
We are removing the appcelerator app from the studio. Removing all references in the repos also