### PR TITLE
Remove Appcelerator references

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ layout: default
       </div>
       <div class="col-md-4">
         <h4><i class="fa fa-code" aria-hidden="true"></i> Mobile SDKs</h4>
-        <p>Native SDKs for iOS, Android, and cross-platform SDKs for Xamarin, Appcelerator, Cordova and others.</p>
+        <p>Native SDKs for iOS, Android, and cross-platform SDKs for Xamarin, Cordova and others.</p>
         <p><a class="btn btn-secondary" href="{{ "/projects/#client-sdks" | relative_url }}" role="button">Learn more &raquo;</a></p>
       </div>
     </div>

--- a/overview.md
+++ b/overview.md
@@ -32,9 +32,9 @@ FeedHenry:
 
 | Component | Description | Source Code
 | -
-| [Client SDKs]({{ "/projects/#client-sdks" | relative_url }}) | Native and hybrid SDKs for client app development on iOS, Android, Windows, Xamarin, Appcelerator, Cordova, and in web apps. | <span class="tag tag-success">Available</span>
+| [Client SDKs]({{ "/projects/#client-sdks" | relative_url }}) | Native and hybrid SDKs for client app development on iOS, Android, Windows, Xamarin, Cordova, and in web apps. | <span class="tag tag-success">Available</span>
 | [Push Notifications]({{ "/projects/#push-notifications" | relative_url }}) | Integration with AeroGear for sending push notifications to any device, regardless of platform or network. | <span class="tag tag-success">Available</span>
-| [App Templates]({{ "/projects/#app-templates" | relative_url }}) | Starting points for building your applications with FeedHenry, including templates for iOS, Android, Xamarin, Appcelerator, Cordova; OAuth2 and SAML examples, push notification and data synchronization examples, and many more. | <span class="tag tag-success">Available</span>
+| [App Templates]({{ "/projects/#app-templates" | relative_url }}) | Starting points for building your applications with FeedHenry, including templates for iOS, Android, Xamarin, Cordova; OAuth2 and SAML examples, push notification and data synchronization examples, and many more. | <span class="tag tag-success">Available</span>
 | [RainCatcher]({{ "/projects/#raincatcher" | relative_url }}) | A set of Node.js modules that can be used with FeedHenry to develop workforce management applications. | <span class="tag tag-success">Available</span>
 | [Core]({{ "/projects/#core" | relative_url }}) | The core components that make up FeedHenry, including drag & drop forms builder, application lifecycle management, reporting, analytics, user management, and more. | <span class="tag tag-info">Coming soon</span>
 | [MBaaS]({{ "/projects/#mbaas" | relative_url }}) | Provides the Node.js runtime environment for high-performance server-side apps (cloud apps) and enables secure integrations with internal systems behind the firewall. | <span class="tag tag-info">Coming soon</span>

--- a/projects.md
+++ b/projects.md
@@ -17,7 +17,7 @@ Native and hybrid SDKs for mobile app development.
 <div class="project-text" markdown="1">
 
 FeedHenry supports a wide range of mobile development technologies. We provide
-support for native iOS, Android, Windows, Xamarin, Appcelerator, Cordova, and
+support for native iOS, Android, Windows, Xamarin, Cordova, and
 other HTML5 app frameworks.
 
 {% include repos.html repos="fh-ios-sdk,fh-ios-swift-sdk,fh-android-sdk,fh-dotnet-sdk,fh-js-sdk" %}
@@ -36,7 +36,7 @@ Starting points for building your applications with FeedHenry.
 
 <div class="project-text" markdown="1">
 
-We've developed app templates for iOS, Android, Xamarin, Appcelerator, Cordova;
+We've developed app templates for iOS, Android, Xamarin, Cordova;
 OAuth2 and SAML examples, push notification and data synchronization examples,
 and many more. We've highlighted a few of the popular ones below.
 


### PR DESCRIPTION
As per ticket [FH-3250](https://issues.jboss.org/browse/FH-3250) we are no longer supporting Titanium/appcelerator apps. Removing all references in the repos also

@pmdarrow 