### PR TITLE
update open issue link

### DIFF
--- a/community.html
+++ b/community.html
@@ -58,7 +58,7 @@ permalink: /community/
         <h4 class="card-title">JIRA</h4>
         <p class="card-text">
           We use JIRA for issue tracking, organizing development sprints, and
-          planning our road map. View the list of <a href="https://issues.jboss.org/projects/FH/issues/FH-2744?filter=allopenissues">open issues</a>.
+          planning our road map. View the list of <a href="https://issues.jboss.org/projects/FH/issues/?filter=allopenissues">open issues</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
**What**
Update the link for `open issues` on the community page

**Why**
It looks like JIRA includes an JIRA number in the link when you view the page. The current number was an old ticket and was closed as out of date. 
