### PR TITLE
Update raincatcher documentation 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ script:
   - bundle exec jekyll build
   - bundle exec htmlproofer ./_site --url-ignore "/#/"
 
-sudo: false
+sudo: required
+before_install:
+  - sudo update-ca-certificates

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 # the `install` step will run `bundle install` by default.
 script:
   - bundle exec jekyll build
-  - bundle exec htmlproofer ./_site --url-ignore "/#/"
+  - bundle exec htmlproofer ./_site --url-ignore "/#/,/www.mankier.com/"
 
 sudo: required
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 rvm:
 - 2.3.3
 

--- a/projects.md
+++ b/projects.md
@@ -86,83 +86,12 @@ A set of Node.js modules that can be used with FeedHenry to develop workforce
 management (WFM) applications.
 
 </div>
-
-<div class="project-text" markdown="1">
-
 <img src="{{ "/assets/images/raincatcher.svg" | relative_url }}" alt="RainCatcher Logo" class="project-logo" />
 
-#### Overview
-
-RainCatcher modules are packaged and distributed via [npm]. They are designed to
-be included in your application using [Browserify]. RainCatcher modules export
-one or more of:
-
-* [Angular.js 1] directives or services providing client-side functionality for
-both the mobile and portal clients.
-* [Express.js] routes providing a REST API to be consumed by the client-side
-portions of the module.
-* FeedHenry sync configurations for enabling data synchronization of a module's
-data. Each module's README file includes more detail on its purpose and how to
-use it.
-
-[npm]: https://www.npmjs.com/
-[browserify]: http://browserify.org/
-[Angular.js 1]: https://angularjs.org/
-[Express.js]: http://expressjs.com/
-
-#### Getting Started
-
-See the [Getting Started Guide](https://github.com/feedhenry-raincatcher/raincatcher-documentation/blob/master/getting-started.adoc).
-
-#### Community
-
+* [RainCatcher project website](http://raincatcher.feedhenry.io)
 * [feedhenry-raincatcher mailing list](http://www.redhat.com/mailman/listinfo/feedhenry-raincatcher)
-* [IRC: #feedhenry-raincatcher on Freenode](irc://irc.freenode.net/feedhenry-raincatcher)
+* [RainCatcher chat](https://gitter.im/FeedhenryRaincatcher/Lobby)
 
-#### FAQ
-
-###### What's the release cycle for RainCatcher?
-
-We have not yet developed a schedule for releases. RainCatcher is still in rapid
-development, and we're going to be working with the larger community to develop
-a cadence.
-
-###### What's the relationship between RainCatcher and RHMAP WFM?
-
-RainCatcher is the upstream project for WFM, where we do work before pulling
-it into our supported product. Features in RainCatcher may or may not ultimately
-land in WFM.
-
-###### I'd like to contribute, do I need to sign a CLA?
-
-No, we do not have a CLA for RainCatcher, but contributors do acknowledge that
-work contributed to RainCatcher is their own work and they have the right to
-make a copyright.
-
-If you have more questions, you are welcome to ask them on the [feedhenry-raincatcher mailing list].
-
-[feedhenry-raincatcher mailing list]: http://www.redhat.com/mailman/listinfo/feedhenry-raincatcher
-
-#### Modules
-
-###### Visual components
-
-{% include repos.html repos="raincatcher-signature,raincatcher-map" %}
-
-###### Angular services and directives
-
-{% include repos.html repos="raincatcher-workflow,raincatcher-workorder,raincatcher-user,raincatcher-risk-assessment,raincatcher-vehicle-inspection,raincatcher-schedule" %}
-
-###### Low-level modules
-
-{% include repos.html repos="raincatcher-sync,raincatcher-appform,raincatcher-mediator" %}
-
-Find the complete list of modules [here](https://github.com/feedhenry-raincatcher).
-
-</div>
-
-
-<div class="project-title" markdown="1">
 
 ## MBaaS
 

--- a/projects.md
+++ b/projects.md
@@ -88,10 +88,11 @@ management (WFM) applications.
 </div>
 <img src="{{ "/assets/images/raincatcher.svg" | relative_url }}" alt="RainCatcher Logo" class="project-logo" />
 
+### RainCatcher Resources
+
 * [RainCatcher project website](http://raincatcher.feedhenry.io)
 * [feedhenry-raincatcher mailing list](http://www.redhat.com/mailman/listinfo/feedhenry-raincatcher)
 * [RainCatcher chat](https://gitter.im/FeedhenryRaincatcher/Lobby)
-
 
 ## MBaaS
 


### PR DESCRIPTION
## Motivation

Update RainCatcher chapter - point to our website and updated documentation.

Udate on feedhenry.org page to no longer list our modules (it will just point to our webpage with documentation