### PR TITLE
Remove FeedHenry Facebook link

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -36,11 +36,11 @@ layout: default
               <i class="fa fa-github" aria-hidden="true"></i> GitHub
             </a>
           </li>
-          <li>
+          <!-- <li>
             <a href="https://twitter.com/feedhenry" class="social">
               <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
             </a>
-          </li>
+          </li> -->
           <li>
             <a href="https://www.facebook.com/FeedHenry" class="social">
               <i class="fa fa-facebook" aria-hidden="true"></i> Facebook

--- a/community.html
+++ b/community.html
@@ -79,10 +79,10 @@ permalink: /community/
             <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
           </a>
           <br>
-          <a href="https://www.facebook.com/FeedHenry" class="social">
+<!--      <a href="https://www.facebook.com/FeedHenry" class="social">
             <i class="fa fa-facebook" aria-hidden="true"></i> Facebook
           </a>
-          <br>
+          <br> -->
           <a href="https://www.youtube.com/channel/UCYvKWvC7UoUXyLcb16doD3g" class="social">
             <i class="fa fa-youtube" aria-hidden="true"></i> YouTube
           </a>


### PR DESCRIPTION
Currently the FeedHenry facebook link goes to some form of food blog. I could not find another facebook group for feedhenry despite best efforts. This PR is to remove the facebook link to ensure we're not sending customers to an unapproved social media page. 